### PR TITLE
Update pg_types.erl

### DIFF
--- a/src/pg_types.erl
+++ b/src/pg_types.erl
@@ -82,7 +82,7 @@ lookup_typsends(TypeInfos, TypeSend) ->
     lists:filter(fun(T) -> T#type_info.typsend =:= TypeSend end, TypeInfos).
 
 lookup_type_info(Pool, Oid) ->
-    case persistent_term:get({?MODULE, Pool, Oid}, undefined) of
+    case persistent_term:get({?MODULE, Pool, Oid}) of
         undefined ->
             unknown_oid;
         TypeInfo ->


### PR DESCRIPTION
Probable typo in function call. Persistent_term only has get/0 and get/1 functions. get/2 throws an error in related module pgo. This edit fixes it.