### PR TITLE
Optionally encode/decode enums from/to atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To configure if json is to be encoded and decoded by a library, include the json
 
 `{pg_types, [{json_config, {jsone, [], [{keys, atom}]}}]}`
 
-To configure if enums should be converted to atoms, set `enum_config` in `pg_types` application environment to the atom `atoms`.
+To configure if enums should be converted to atoms, set `enum_config` in `pg_types` application environment to the atom `atoms`, or the atom `existing_atoms`. Using `existing_atoms` will result in `binary_to_existing_atom(Value, utf8)` being used to decode values.
 
 `{pg_types, [{enum_config, atoms}]}`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ To configure if json is to be encoded and decoded by a library, include the json
 
 `{pg_types, [{json_config, {jsone, [], [{keys, atom}]}}]}`
 
+To configure if enums should be converted to atoms, set `enum_config` in `pg_types` application environment to the atom `atoms`.
+
+`{pg_types, [{enum_config, atoms}]}`
+
 ### Incomplete Types
 
 * Timezones: I don't think the `timestamptz` is done

--- a/src/pg_enum.erl
+++ b/src/pg_enum.erl
@@ -21,6 +21,8 @@ encode(Atom, #type_info{config = atoms} = Args) when is_atom(Atom) ->
 encode(Text, _) ->
     [<<(iolist_size(Text)):?int32>>, Text].
 
+decode(Text, #type_info{config = existing_atoms}) ->
+    binary_to_existing_atom(Text, utf8);
 decode(Text, #type_info{config = atoms}) ->
     binary_to_atom(Text, utf8);
 decode(Text, _) ->

--- a/src/pg_enum.erl
+++ b/src/pg_enum.erl
@@ -1,0 +1,27 @@
+-module(pg_enum).
+
+-behaviour(pg_types).
+
+-export([init/1,
+         encode/2,
+         decode/2]).
+
+-include("pg_types.hrl").
+-include("pg_protocol.hrl").
+
+init(#{enum_config := Config}) ->
+    {[<<"enum_send">>], Config};
+init(_Opts) ->
+    Config = application:get_env(pg_types, enum_config, []),
+    {[<<"enum_send">>], Config}.
+
+
+encode(Atom, #type_info{config = atoms} = Args) when is_atom(Atom) ->
+    encode(atom_to_binary(Atom, utf8), Args);
+encode(Text, _) ->
+    [<<(iolist_size(Text)):?int32>>, Text].
+
+decode(Text, #type_info{config = atoms}) ->
+    binary_to_atom(Text, utf8);
+decode(Text, _) ->
+    Text.

--- a/src/pg_raw.erl
+++ b/src/pg_raw.erl
@@ -11,8 +11,8 @@
 init(_Opts) ->
     {[<<"bpcharsend">>, <<"textsend">>,
       <<"varcharsend">>, <<"charsend">>,
-      <<"byteasend">>,  <<"enum_send">>,
-      <<"unknownsend">>, <<"citextsend">>], []}.
+      <<"byteasend">>, <<"unknownsend">>,
+      <<"citextsend">>], []}.
 
 encode(Text, _) ->
     [<<(iolist_size(Text)):?int32>>, Text].


### PR DESCRIPTION
- split off `pg_enum` from `pg_raw` so we can deal with enums separately
- add an option to marshal from/to atoms

Thoughts/questions:
- should this be the default behaviour?
- should we "insist" `utf8` is used for the conversions?
  I can't really imagine cases where this wouldn't work out. If they arise, I suppose people can still add a custom module for handling `enums`, though I'm curious what folks here think
- should we use `binary_to_existing_atom/2` instead?
  Seems to me like enums in db-schema's are an unlikely source for introducing too many atoms
- the config format can probably benefit from some 'shedding.