### PR TITLE
Make encoding of dates work

### DIFF
--- a/src/pg_date.erl
+++ b/src/pg_date.erl
@@ -14,25 +14,10 @@ init(_Opts) ->
     {[<<"date_send">>], []}.
 
 encode(Date, _TypeInfo) ->
-    [<<4:?int32>>, encode_date(Date)].
+    <<4:?int32, (encode_date(Date)):?int32>>.
 
 decode(<<Date:?int32>>, _TypeInfo) ->
     calendar:gregorian_days_to_date(Date + ?POSTGRESQL_GD_EPOCH).
 
-encode_date({Y, M, D}) ->
-    M2 = case M > 2 of
-        true ->
-            M + 1;
-        false ->
-            M + 13
-    end,
-    Y2 = case M > 2 of
-        true ->
-            Y + 4800;
-        false ->
-            Y + 4799
-    end,
-    C = Y2 div 100,
-    J1 = Y2 * 365 - 32167,
-    J2 = J1 + (Y2 div 4 - C + C div 4),
-    J2 + 7834 * M2 div 256 + D.
+encode_date(Date) ->
+    calendar:date_to_gregorian_days(Date) - ?POSTGRESQL_GD_EPOCH.


### PR DESCRIPTION
The changes to `encode_date/1` aren't that important - it just seems to make sense to use the inverse.

The important bit is the change to `encode/2`. The current code would result in something like  `[<<0,0,0,4>>,2458776]` which makes [this call to `iolist_size/1`](https://github.com/erleans/pgo/blob/6af914294e82b20d5353ff557fbf749894ee58cc/src/pgo_protocol.erl#L129) freak out.