### PR TITLE
add type_info records for elem_oid and comp_oids to type_info

### DIFF
--- a/include/pg_types.hrl
+++ b/include/pg_types.hrl
@@ -9,5 +9,7 @@
                     output     :: binary(),
                     input      :: binary(),
                     elem_oid   :: integer(),
+                    elem_type  :: #type_info{} | undefined,
                     base_oid   :: integer(),
-                    comp_oids  :: [integer()]}).
+                    comp_oids  :: [integer()],
+                    comp_types :: [#type_info{}] | undefined}).

--- a/src/pg_record.erl
+++ b/src/pg_record.erl
@@ -13,47 +13,48 @@ init(_Opts) ->
     {[<<"record_send">>], []}.
 
 encode(Tuple, #type_info{pool=Pool,
-                         comp_oids=Oids}) ->
-    Data = encode_tuple(tuple_to_list(Tuple), Oids, Pool),
+                         comp_types=CompTypes}) ->
+    Data = encode_tuple(tuple_to_list(Tuple), CompTypes, Pool),
     [<<(iolist_size(Data) + 4):?int32, (erlang:tuple_size(Tuple)):?int32>> | Data].
 
 decode(<<Count:?int32, Data/binary>>, #type_info{pool=Pool,
-                                                 comp_oids=[]}) ->
-    Types = [],
-    decode_tuple_no_oids(Data, Count, Pool, Types);
+                                                 comp_types=[]}) ->
+    decode_tuple_no_oids(Data, Count, Pool, []);
+decode(<<Count:?int32, Data/binary>>, #type_info{pool=Pool,
+                                                 comp_types=undefined}) ->
+    decode_tuple_no_oids(Data, Count, Pool, []);
 decode(<<_:?int32, Data/binary>>, #type_info{pool=Pool,
-                                             comp_oids=Oids}) ->
+                                             comp_types=CompTypes}) ->
     Types = [],
-    decode_tuple(Data, Oids, Pool, Types).
+    decode_tuple(Data, CompTypes, Pool, Types).
 %%
 
-encode_tuple(Elems, Oids, Pool) ->
-    encode_tuple(Elems, Oids, Pool, []).
+encode_tuple(Elems, CompTypes, Pool) ->
+    encode_tuple(Elems, CompTypes, Pool, []).
 
 encode_tuple([], [], _, Acc) ->
     Acc;
-encode_tuple([null | T], [Oid | Oids], Pool, Acc) ->
+encode_tuple([null | T], [#type_info{oid=Oid} | CompTypes], Pool, Acc) ->
     EncodedElem = <<-1:?int32>>,
-    encode_tuple(T, Oids, Pool, Acc ++ [<<Oid:?int32>>, EncodedElem]);
-encode_tuple([H | T], [Oid | Oids], Pool, Acc) ->
-    TypeInfo=#type_info{module=Mod} = pg_types:lookup_type_info(Pool, Oid),
+    encode_tuple(T, CompTypes, Pool, Acc ++ [<<Oid:?int32>>, EncodedElem]);
+encode_tuple([H | T], [TypeInfo=#type_info{oid=Oid,
+                                           module=Mod} | CompTypes], Pool, Acc) ->
     EncodedElem = Mod:encode(H, TypeInfo),
-    encode_tuple(T, Oids, Pool, Acc ++ [<<Oid:?int32>>, EncodedElem]).
+    encode_tuple(T, CompTypes, Pool, Acc ++ [<<Oid:?int32>>, EncodedElem]).
 
-decode_tuple(Data, Oids, Pool, Types) ->
-    decode_tuple(Data, Oids, Pool, Types, []).
+decode_tuple(Data, CompTypes, Pool, Types) ->
+    decode_tuple(Data, CompTypes, Pool, Types, []).
 
 decode_tuple(<<>>, [], _, _Types, Acc) ->
     list_to_tuple(lists:reverse(Acc));
 decode_tuple(<<_Oid:?int32, -1:?int32, RestData/binary>>,
-             [_Oid | RestOids], Pool, Types, Acc) ->
+             [_TypeInfo | CompTypes], Pool, Types, Acc) ->
     Elem = null,
-    decode_tuple(RestData, RestOids, Pool, Types, [Elem | Acc]);
+    decode_tuple(RestData, CompTypes, Pool, Types, [Elem | Acc]);
 decode_tuple(<<_Oid:?int32, Size:?int32, Data:Size/binary, RestData/binary>>,
-             [Oid | RestOids], Pool, Types, Acc) ->
-    TypeInfo=#type_info{module=Mod} = pg_types:lookup_type_info(Pool, Oid),
+             [TypeInfo=#type_info{module=Mod} | CompTypes], Pool, Types, Acc) ->
     Elem = Mod:decode(Data, TypeInfo),
-    decode_tuple(RestData, RestOids, Pool, Types, [Elem | Acc]).
+    decode_tuple(RestData, CompTypes, Pool, Types, [Elem | Acc]).
 
 decode_tuple_no_oids(Data, Count, Pool, Types) ->
     decode_tuple_no_oids(Data, Count, Pool, Types, []).

--- a/src/pg_types.erl
+++ b/src/pg_types.erl
@@ -7,7 +7,7 @@
          format_error/1,
          lookup_type_info/2,
          update/3,
-         update/4]).
+         update_map/3]).
 
 -include_lib("pg_types.hrl").
 
@@ -56,22 +56,29 @@ decode(Pool, Value, Oid) ->
 format_error({badarg, {Module, Reason}}) ->
     Module:format_error(Reason).
 
--spec update(atom(), [type_info()], map()) -> persistent_term.
+-spec update(atom(), [type_info()], map()) -> ok.
 update(Pool, TypeInfos, Parameters) ->
-    update(Pool, TypeInfos, Parameters, persistent_term).
+    Types = update_map(TypeInfos, Parameters, #{}),
+    maps:map(fun(Oid, TypeInfo) ->
+                     persistent_term:put({?MODULE, Pool, Oid}, TypeInfo)
+             end, Types),
+    ok.
 
--spec update(atom(), [type_info()], map(), map() | persistent_term) -> map() | persistent_term.
-update(Pool, TypeInfos, Parameters, ToUpdate) ->
+-spec update_map([type_info()], map(), map()) -> map().
+update_map(TypeInfos, Parameters, ToUpdate) ->
     {ok, Modules} = application:get_key(pg_types, modules),
     Modules1 = Modules ++ application:get_env(pg_types, modules, []),
-    lists:foldl(fun(Module, Acc) ->
-                        add_type(Pool, Module, TypeInfos, Parameters, Acc)
-                end, ToUpdate, Modules1).
+    Result = lists:foldl(fun(Module, Acc) ->
+                                 add_type(Module, TypeInfos, Parameters, Acc)
+                         end, ToUpdate, Modules1),
+    maps:map(fun(_K, TypeInfo) ->
+                     maybe_update_subtypes(Result, TypeInfo)
+             end, Result).
 
-add_type(Pool, Module, TypeInfos, Parameters, ToUpdate) ->
+add_type(Module, TypeInfos, Parameters, ToUpdate) ->
     try Module:init(Parameters) of
         {TypeSends, Config} ->
-            update_for_typesends(Module, Config, TypeSends, Pool, TypeInfos, ToUpdate)
+            update_for_typesends(Module, Config, TypeSends, TypeInfos, ToUpdate)
     catch
         _:_ ->
             %% expected for modules that aren't for encode/decode
@@ -89,16 +96,27 @@ lookup_type_info(Pool, Oid) ->
             TypeInfo
     end.
 
-update_for_typesends(Module, Config, TypeSends, Pool, TypeInfos, ToUpdate) ->
+update_for_typesends(Module, Config, TypeSends, TypeInfos, Map) ->
     lists:foldl(fun(TypeSend, Acc) ->
-                    lists:foldl(fun(TypeInfo, Acc1) ->
-                                        update_entry(Pool, TypeInfo#type_info{module=Module,
-                                                                              config=Config}, Acc1)
-                                end, Acc,  lookup_typsends(TypeInfos, TypeSend))
-                end, ToUpdate, TypeSends).
+                    lists:foldl(fun(TypeInfo=#type_info{oid=Oid}, Acc1) ->
+                                        Acc1#{Oid => TypeInfo#type_info{module=Module,
+                                                                        config=Config}}
+                                end, Acc, lookup_typsends(TypeInfos, TypeSend))
+                end, Map, TypeSends).
 
-update_entry(_Pool, TypeInfo=#type_info{oid=Oid}, ToUpdate) when is_map(ToUpdate) ->
-    ToUpdate#{Oid => TypeInfo};
-update_entry(Pool, TypeInfo=#type_info{oid=Oid}, ToUpdate=persistent_term) ->
-    persistent_term:put({?MODULE, Pool, Oid}, TypeInfo),
-    ToUpdate.
+maybe_update_subtypes(_Map, unknown_oid) ->
+    unknown_oid;
+maybe_update_subtypes(Map, TypeInfo) ->
+    TypeInfo1 = maybe_add_elem_type(Map, TypeInfo),
+    maybe_add_comp_types(Map, TypeInfo1).
+
+maybe_add_elem_type(_, T=#type_info{elem_oid=0}) ->
+    T;
+maybe_add_elem_type(Map, T=#type_info{elem_oid=ElemOid}) ->
+    T#type_info{elem_type=maybe_update_subtypes(Map, maps:get(ElemOid, Map, unknown_oid))}.
+
+maybe_add_comp_types(_, T=#type_info{comp_oids=[]}) ->
+    T;
+maybe_add_comp_types(Map, T=#type_info{comp_oids=CompOids}) ->
+    CompTypes = [maybe_update_subtypes(Map, maps:get(CompOid, Map, unknown_oid)) || CompOid <- CompOids],
+    T#type_info{comp_types=CompTypes}.


### PR DESCRIPTION
pg_array and pg_record now no longer have to lookup the type_info
for an oid when encoding/decoding, except for the case of a record
without existing comp_oids. This case of no comp_oids is for
bare tuples.