### PR TITLE
Support UTC offset in pg_timestampz::encode/2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Compile
       run: rebar3 compile
 
+    - name: Eunit tests
+      run: rebar3 eunit
+
     - name: Proper tests
       run: rebar3 as test proper
 

--- a/src/pg_timestamp.erl
+++ b/src/pg_timestamp.erl
@@ -49,9 +49,24 @@ encode_timestamp(infinity) ->
     16#7FFFFFFFFFFFFFFF;
 encode_timestamp('-infinity') ->
     -16#8000000000000000;
+encode_timestamp({{Year, Month, Day}, {Hour, Minute, Seconds}, {HourOffset, MinuteOffset}}) when is_integer(Seconds) ->
+    Sign = determine_sign(HourOffset),
+    OffsetFromHours = calendar:time_to_seconds({abs(HourOffset), 0, 0}),
+    OffsetFromMinutes = calendar:time_to_seconds({0, MinuteOffset, 0}),
+    DatetimeSeconds = calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {Hour, Minute, Seconds}}) - ?POSTGRESQL_GS_EPOCH,
+    (DatetimeSeconds + OffsetFromHours * Sign + OffsetFromMinutes) * 1000000;
 encode_timestamp(Datetime={{_, _, _}, {_, _, Seconds}}) when is_integer(Seconds)->
     Secs = calendar:datetime_to_gregorian_seconds(Datetime) - ?POSTGRESQL_GS_EPOCH,
     Secs * 1000000;
+encode_timestamp({{Year, Month, Day}, {Hours, Minutes, Seconds}, {HourOffset, MinuteOffset}}) when is_float(Seconds) ->
+    Sign = determine_sign(HourOffset),
+    OffsetFromHours = calendar:time_to_seconds({abs(HourOffset), 0, 0}),
+    OffsetFromMinutes = calendar:time_to_seconds({0, MinuteOffset, 0}),
+    IntegerSeconds = trunc(Seconds),
+    US = trunc((Seconds - IntegerSeconds) * 1000000),
+    DatetimeSeconds = calendar:datetime_to_gregorian_seconds({{Year, Month, Day},
+                                                   {Hours, Minutes, IntegerSeconds}}) - ?POSTGRESQL_GS_EPOCH,
+    ((DatetimeSeconds + OffsetFromHours * Sign + OffsetFromMinutes) * 1000000) + US;
 encode_timestamp({{Year, Month, Day}, {Hours, Minutes, Seconds}}) when is_float(Seconds)->
     IntegerSeconds = trunc(Seconds),
     US = trunc((Seconds - IntegerSeconds) * 1000000),
@@ -88,3 +103,10 @@ add_usecs(Secs, 0) ->
     Secs;
 add_usecs(Secs, USecs) ->
     Secs + (USecs / 1000000).
+
+% When the hour offset is positive, you are in the future and therefore
+% need to subtract the hours to get to UTC.
+determine_sign(HourOffset) when HourOffset >= 0 ->
+    -1;
+determine_sign(_) ->
+    1.

--- a/src/pg_timestamp.erl
+++ b/src/pg_timestamp.erl
@@ -49,6 +49,9 @@ encode_timestamp(infinity) ->
     16#7FFFFFFFFFFFFFFF;
 encode_timestamp('-infinity') ->
     -16#8000000000000000;
+% A timestamp with a positive offset is a time in the future, compared to UTC,
+% and therefore you need to subtract the hour and minutes to generate a UTC
+% time. Please see 'test/timestamptz_tests.erl' for some examples.
 encode_timestamp({{Year, Month, Day}, {Hour, Minute, Seconds}, {HourOffset, MinuteOffset}}) when is_integer(Seconds), MinuteOffset >= 0 ->
     Sign = determine_sign(HourOffset),
     OffsetFromHours = calendar:time_to_seconds({abs(HourOffset), 0, 0}),

--- a/src/pg_timestampz.erl
+++ b/src/pg_timestampz.erl
@@ -19,4 +19,4 @@ decode(Bin, _TypeInfo) ->
     pg_timestamp:decode_timestamp(Bin, []).
 
 type_spec() ->
-    "{{Year::integer(), Month::1..12, Day::1..31}, {Hours::0..23, Minutes::0..59, Seconds::0..59 | float()}, {HourOffset::-15..15, MinuteOffset::0..59}}".
+    "{{Year::integer(), Month::1..12, Day::1..31}, {Hours::integer(), Minutes::integer(), Seconds::integer() | float()}, {HourOffset::integer(), MinuteOffset::integer()}}".

--- a/src/pg_timestampz.erl
+++ b/src/pg_timestampz.erl
@@ -19,4 +19,4 @@ decode(Bin, _TypeInfo) ->
     pg_timestamp:decode_timestamp(Bin, []).
 
 type_spec() ->
-    pg_timestamp:type_spec().
+    "{{Year::integer(), Month::1..12, Day::1..31}, {Hours::0..23, Minutes::0..59, Seconds::0..59 | float()}, {HourOffset::-15..15, MinuteOffset::0..59}}".

--- a/src/pg_timestampz.erl
+++ b/src/pg_timestampz.erl
@@ -19,4 +19,4 @@ decode(Bin, _TypeInfo) ->
     pg_timestamp:decode_timestamp(Bin, []).
 
 type_spec() ->
-    "{{Year::integer(), Month::1..12, Day::1..31}, {Hours::integer(), Minutes::integer(), Seconds::integer() | float()}, {HourOffset::integer(), MinuteOffset::integer()}}".
+    "{{Year::integer(), Month::1..12, Day::1..31}, {Hours::integer(), Minutes::integer(), Seconds::integer() | float()}, {HourOffset::integer(), MinuteOffset::pos_integer()}}".

--- a/test/prop_timestamp.erl
+++ b/test/prop_timestamp.erl
@@ -9,5 +9,21 @@ prop_tz_int_sec_codec() ->
     ?FORALL(Val, int_timestamp(),
             proper_lib:codec(pg_timestampz, [], Val)).
 
+prop_tz_offset_codec() ->
+    ?FORALL(Val, utc_offset_timestamp(),
+            proper_lib:codec(pg_timestampz, [], without_offset(Val))).
+
+without_offset({{Year, Month, Day}, {Hour, Minute, Second}, {HourOffset, MinuteOffset}}) ->
+    Sign = case HourOffset >= 0 of
+        true -> 1;
+        false -> -1
+    end,
+    OffsetSeconds = calendar:time_to_seconds({abs(HourOffset), MinuteOffset, 0}),
+    DatetimeSeconds = calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {Hour, Minute, Second}}),
+    calendar:gregorian_seconds_to_datetime(DatetimeSeconds + OffsetSeconds * Sign).
+
 int_timestamp() ->
     {proper_lib:date_gen(), proper_lib:int_time_gen()}.
+
+utc_offset_timestamp() ->
+    {proper_lib:date_gen(), proper_lib:int_time_gen(), proper_lib:utc_offset_gen()}.

--- a/test/prop_timestamp.erl
+++ b/test/prop_timestamp.erl
@@ -11,16 +11,17 @@ prop_tz_int_sec_codec() ->
 
 prop_tz_offset_codec() ->
     ?FORALL(Val, utc_offset_timestamp(),
-            proper_lib:codec(pg_timestampz, [], without_offset(Val))).
+            proper_lib:codec(pg_timestampz, [], Val, apply_offset(Val))).
 
-without_offset({{Year, Month, Day}, {Hour, Minute, Second}, {HourOffset, MinuteOffset}}) ->
+apply_offset({{Year, Month, Day}, {Hour, Minute, Second}, {HourOffset, MinuteOffset}}) ->
     Sign = case HourOffset >= 0 of
-        true -> 1;
-        false -> -1
+        true -> -1;
+        false -> 1
     end,
-    OffsetSeconds = calendar:time_to_seconds({abs(HourOffset), MinuteOffset, 0}),
+    OffsetHours = calendar:time_to_seconds({abs(HourOffset), 0, 0}),
+    OffsetMinutes = calendar:time_to_seconds({0, MinuteOffset, 0}),
     DatetimeSeconds = calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {Hour, Minute, Second}}),
-    calendar:gregorian_seconds_to_datetime(DatetimeSeconds + OffsetSeconds * Sign).
+    calendar:gregorian_seconds_to_datetime(DatetimeSeconds + OffsetHours * Sign + OffsetMinutes * Sign).
 
 int_timestamp() ->
     {proper_lib:date_gen(), proper_lib:int_time_gen()}.

--- a/test/proper_lib.erl
+++ b/test/proper_lib.erl
@@ -3,7 +3,7 @@
 -export([codec/3, codec/4]).
 
 -export([int16/0, int32/0, int64/0,
-         date_gen/0, int_time_gen/0]).
+         date_gen/0, int_time_gen/0, utc_offset_gen/0]).
 
 -include_lib("proper/include/proper.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -38,6 +38,10 @@ date_gen() ->
         proper_types:integer(1, 12),
         proper_types:integer(1, 31)},
        calendar:valid_date(Date)).
+
+utc_offset_gen() ->
+    {proper_types:integer(-15, 15),
+     proper_types:integer(0, 59)}.
 
 int_time_gen() ->
     {proper_types:integer(0, 23),

--- a/test/timestamptz_tests.erl
+++ b/test/timestamptz_tests.erl
@@ -1,0 +1,33 @@
+-module(timestamptz_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+negative_offset_timestamptz_test() ->
+    ?assertEqual(
+        proper_lib:encode_decode(
+            pg_timestampz,
+            [],
+            {{2024, 3, 1}, {1, 0, 0}, {-5, 15}}
+        ),
+        {{2024, 3, 1}, {6, 15, 0}}
+    ).
+
+positive_offset_timestamptz_test() ->
+    ?assertEqual(
+        proper_lib:encode_decode(
+            pg_timestampz,
+            [],
+            {{2024, 3, 1}, {1, 0, 0}, {5, 15}}
+        ),
+        {{2024, 2, 29}, {19, 45, 0}}
+    ).
+
+no_offset_timestamptz_test() ->
+    ?assertEqual(
+        proper_lib:encode_decode(
+            pg_timestampz,
+            [],
+            {{2024, 3, 1}, {1, 0, 0}, {0, 0}}
+        ),
+        {{2024, 3, 1}, {1, 0, 0}}
+    ).


### PR DESCRIPTION
Working on this issue https://github.com/erleans/pgo/issues/70

The first step is allowing the UTC offtset in the encoding function.

IIUC, you'll need to add a new tag for `v0.4.1` after we commit this. https://github.com/erleans/pgo/blob/7f39da0b570af5929c0985fc9ca92af661defd6e/rebar.config#L4 <- is how this is used in pgo so it should automatically pick up the new minor version.

Note, I was already able to test a round trip encode/decode in https://github.com/erleans/pgo/pull/98 using https://rebar3.org/docs/configuration/dependencies/#checkout-dependencies