### PR TITLE
Timestamps with time zone can be returned as Erlang system time in rfc3339 binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _build
 .idea
 *.iml
 rebar3.crashdump
+pg_types.d

--- a/README.md
+++ b/README.md
@@ -33,9 +33,44 @@ To configure if enums should be converted to atoms, set `enum_config` in `pg_typ
 
 ### Datetimes
 
+#### Timestamps
 Timestamps can be returned as Erlang system time in seconds (as an integer or float):
 
 `{pg_types, [{timestamp_config, float_system_time_seconds | integer_system_time_seconds}]}`
+
+Future plans include allowing this to be set per-query instead of globally.
+
+#### Timestamps with time zone
+Timestamps with time zone can be returned as Erlang system time in rfc3339 binary:
+
+`{pg_types, [{timestampz_config, rfc3339_bin}]}`
+
+```
+CREATE TABLE public.app_version (
+    id bigserial NOT NULL,
+    ...
+    created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL, -- 2025-02-21 08:33:16.268288+08:00
+    CONSTRAINT app_version_pkey PRIMARY KEY (id)
+);
+```
+```
+(imboy@imboy.local)1> pgo:query("select created_at FROM app_version limit 1;").
+Without configuration timestampz_config:
+#{command => select,
+  rows =>
+      [#{<<"created_at">> =>
+             {{2025,2,25},{23,45,34.492948}}],
+  num_rows => 1}
+
+With {pg_types, [{timestampz_config, rfc3339_bin}]} the result is:
+
+#{command => select,
+  rows =>
+      [#{<<"created_at">> =>
+             <<"2025-02-26 08:45:34.493366+08:00">>}],
+  num_rows => 1}
+
+```
 
 Future plans include allowing this to be set per-query instead of globally.
 

--- a/src/pg_timestamp.erl
+++ b/src/pg_timestamp.erl
@@ -64,6 +64,10 @@ encode_timestamp(SystemTime) when is_integer(SystemTime) ->
 -spec decode_timestamp(binary(), config() | []) -> datetime().
 decode_timestamp(<<16#7FFFFFFFFFFFFFFF:?int64>>, _) -> infinity;
 decode_timestamp(<<-16#8000000000000000:?int64>>, _) -> '-infinity';
+decode_timestamp(<<Timestamp:?int64>>, rfc3339_bin) ->
+    MS = Timestamp + (?POSTGRESQL_GS_EPOCH * 1000000) - (62167219200 * 1000000),
+    Dtz = calendar:system_time_to_rfc3339(MS, [{unit, microsecond}, {time_designator, $\s}, {offset, ""}]),
+    list_to_binary(Dtz);
 decode_timestamp(<<Timestamp:?int64>>, float_system_time_seconds) ->
     %% Note: We do this instead of just dividing by 1000000 to not end up with float inaccuracies
     USecs = Timestamp rem 1000000,

--- a/src/pg_timestampz.erl
+++ b/src/pg_timestampz.erl
@@ -16,7 +16,8 @@ encode(Timestamp, _TypeInfo) ->
     <<8:?int32, (pg_timestamp:encode_timestamp(Timestamp)):?int64>>.
 
 decode(Bin, _TypeInfo) ->
-    pg_timestamp:decode_timestamp(Bin, []).
+    Conf = application:get_env(pg_types, timestampz_config, []),
+    pg_timestamp:decode_timestamp(Bin, Conf).
 
 type_spec() ->
     pg_timestamp:type_spec().

--- a/src/pg_types.app.src
+++ b/src/pg_types.app.src
@@ -1,14 +1,9 @@
-{application, pg_types,
- [{description, "Erlang library for encoding and decoding postgres data types"},
-  {vsn, git},
-  {registered, []},
-  {applications,
-   [kernel,
-    stdlib
-   ]},
-  {env,[]},
-  {modules, []},
-
-  {licenses, ["Apache 2.0"]},
-  {links, [{"Github", "https://github.com/tsloughter/pg_types"}]}
- ]}.
+{application,pg_types,
+             [{description,"Erlang library for encoding and decoding postgres data types"},
+              {vsn,"1033dbd-dirty"},
+              {registered,[]},
+              {applications,[kernel,stdlib]},
+              {env,[]},
+              {modules,[]},
+              {licenses,["Apache 2.0"]},
+              {links,[{"Github","https://github.com/tsloughter/pg_types"}]}]}.


### PR DESCRIPTION
Timestamps with time zone can be returned as Erlang system time in rfc3339 binary:

* sys.config
```
{pg_types, [{timestampz_config, rfc3339_bin}]}
```

* ddl: 
```
CREATE TABLE public.app_version (
    id bigserial NOT NULL,
    ...
    created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL, -- 2025-02-21 08:33:16.268288+08:00
    CONSTRAINT app_version_pkey PRIMARY KEY (id)
);
```

* erl shell
```
(imboy@imboy.local)1> pgo:query("select created_at FROM app_version limit 1;").
Without configuration timestampz_config:
#{command => select,
  rows =>
      [#{<<"created_at">> =>
             {{2025,2,25},{23,45,34.492948}}],
  num_rows => 1}

With {pg_types, [{timestampz_config, rfc3339_bin}]} the result is:

#{command => select,
  rows =>
      [#{<<"created_at">> =>
             <<"2025-02-26 08:45:34.493366+08:00">>}],
  num_rows => 1}
```