### PR TITLE
Using incorrect form for infinity in pg_float8 proper generator

### DIFF
--- a/test/prop_float.erl
+++ b/test/prop_float.erl
@@ -18,4 +18,4 @@ float64() ->
       [{85, proper_types:float()},
        {5, 'NaN'},
        {5, '-infinity'},
-       {5, plus_infinity}]).
+       {5, infinity}]).


### PR DESCRIPTION
The typespec in float8 https://github.com/tsloughter/pg_types/blob/2e78c4960929a3a55d3fc08426228acca7fe5422/src/pg_float8.erl#L40-L41

It uses `plus_infinity` in the proper generator.