### PR TITLE
Fix decoding inet with netmask

### DIFF
--- a/src/pg_inet.erl
+++ b/src/pg_inet.erl
@@ -39,7 +39,11 @@ decode(<<?INET6, Mask:8, 1, ?IP6_SIZE, Bin/binary>>, _) ->
 decode(<<?INET, ?MAX_IP_MASK, 0, ?IP_SIZE, Bin/binary>>, _) ->
     list_to_tuple(binary_to_list(Bin));
 decode(<<?INET6, ?MAX_IP6_MASK, 0, ?IP6_SIZE, Bin/binary>>, _) ->
-    list_to_tuple([X || <<X:16>> <= Bin]).
+    list_to_tuple([X || <<X:16>> <= Bin]);
+decode(<<?INET, Mask:8, 0, ?IP_SIZE, Bin/binary>>, _) ->
+    {list_to_tuple(binary_to_list(Bin)), Mask};
+decode(<<?INET6, Mask:8, 0, ?IP6_SIZE, Bin/binary>>, _) ->
+    {list_to_tuple([X || <<X:16>> <= Bin]), Mask}.
 
 type_spec() ->
     "{0..255, 0..255, 0..255, 0..255} | "


### PR DESCRIPTION
I got the following error when trying to select an `inet` value with a netmask other than 32:
```
1> pgo:query("SELECT '192.168.0.1/24'::inet").
** exception error: no function clause matching 
                    pg_inet:decode(<<2,24,0,4,192,168,0,1>>,
                                   ...
```
It looks like `pg_inet:decode` currently matches on the third byte depending on the netmask value. This byte however is a flag indicating whether the type is `inet` or `cidr`[^1]. Unless we want to return this type information, it should just be ignored.

I also changed the encoding for consistency, the `is_cidr` flag is ignored by postgres[^2].

[^1]: https://github.com/postgres/postgres/blob/e849bd551c323a384f2b14d20a1b7bfaa6127ed7/src/backend/utils/adt/network.c#L278
[^2]: https://github.com/postgres/postgres/blob/e849bd551c323a384f2b14d20a1b7bfaa6127ed7/src/backend/utils/adt/network.c#L217