### PR TITLE
fix: replace persistent term usage with ets table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,21 @@ A type module implements the `pg_types` behaviour. `init/1` must return a 2-tupl
 
 ## Using
 
-`pg_types:update/3` will lookup all type modules, based on the modules in `pg_types` and the `pg_types` application environment variable `modules`, which is how to add implementations not found in this application. The update function takes an atom namespace that usually corresponds to whatever pool the client is setting up types for, a list of `type_info` records populated from the Postgres table's rows and any option map to pass to each type module's `init/1`. It then sets a `persistent_term` with the `type_info` record updated to include the module that implement's the types `typsend` and the configuration returned from `init/1`.
+`pg_types:update/3` will lookup all type modules, based on the modules in
+`pg_types` and the `pg_types` application environment variable `modules`, which
+is how to add implementations not found in this application. The update function
+takes an atom namespace that usually corresponds to whatever pool the client is
+setting up types for, a list of `type_info` records populated from the Postgres
+table's rows and any option map to pass to each type module's `init/1`. It then
+inserts into an ETS the `type_info` record updated to include the module that
+implement's the types `typsend` and the configuration returned from `init/1`.
 
-`pg_types:update/4` with a map as the last argument to update a map with `oid() => type_info()}` instead of having them inserted into a `persistent_term`.
+`pg_types:update/4` with a map as the last argument to update a map with `oid()
+=> type_info()}` instead of having them inserted into the ETS table.
 
-To find the module for encoding/decoding an oid use `lookup_type_info/2`, passing the namespace (pool) and oid, it will return the `type_info` record with `module` and `config` set.
+To find the module for encoding/decoding an oid use `lookup_type_info/2`,
+passing the namespace (pool) and oid, it will return the `type_info` record with
+`module` and `config` set.
 
 ## Configuring
 

--- a/include/pg_types.hrl
+++ b/include/pg_types.hrl
@@ -13,3 +13,5 @@
                     base_oid   :: integer(),
                     comp_oids  :: [integer()],
                     comp_types :: [#type_info{}] | undefined}).
+
+-define(PG_TYPES_TABLE, pg_types_table).

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-{xref_ignores, [{pg_types, format_error, 1},
+{xref_ignores, [{pg_types_server, start_link, 0},
+                {pg_types, format_error, 1},
                 {pg_types, update_map, 3},
                 {pg_codec, behaviour_info, 1},
                 {pg_codec, decode, 4},

--- a/src/pg_array.erl
+++ b/src/pg_array.erl
@@ -64,18 +64,18 @@ get_array_dims(Row) ->
 encode_array_binary_header(Dims, HasNulls, ElementTypeOID) ->
     NDims = length(Dims),
     Flags = if
-        HasNulls -> 1;
-        true -> 0
-    end,
+                HasNulls -> 1;
+                true -> 0
+            end,
     EncodedDimensions = [<<Dim:32/integer, 1:32/integer>> || Dim <- Dims],
     [<<NDims:32/integer, Flags:32/integer, ElementTypeOID:32/integer>>, EncodedDimensions].
 
 decode_array_bin(<<Dimensions:32/signed-integer, _Flags:32/signed-integer,
                    _ElementOID:32/signed-integer, Remaining/binary>>, TypeInfo) ->
     {RemainingData, DimsInfo} = lists:foldl(fun(_Pos, {Bin, Acc}) ->
-                <<Nbr:32/signed-integer, LBound:32/signed-integer, Next/binary>> = Bin,
-                {Next, [{Nbr, LBound} | Acc]}
-        end, {Remaining, []}, lists:seq(1, Dimensions)),
+                                                    <<Nbr:32/signed-integer, LBound:32/signed-integer, Next/binary>> = Bin,
+                                                    {Next, [{Nbr, LBound} | Acc]}
+                                            end, {Remaining, []}, lists:seq(1, Dimensions)),
     DataList = decode_array_bin_aux(RemainingData, TypeInfo, []),
     {array, Expanded} = expand(DataList, DimsInfo),
     Expanded.

--- a/src/pg_types.app.src
+++ b/src/pg_types.app.src
@@ -2,6 +2,7 @@
  [{description, "Erlang library for encoding and decoding postgres data types"},
   {vsn, git},
   {registered, []},
+  {mod, {pg_types_app, []}},
   {applications,
    [kernel,
     stdlib

--- a/src/pg_types.erl
+++ b/src/pg_types.erl
@@ -77,7 +77,7 @@ format_error(Error) ->
 update(Pool, TypeInfos, Parameters) ->
     Types = update_map(TypeInfos, Parameters, #{}),
     maps:map(fun(Oid, TypeInfo) ->
-                     persistent_term:put({?MODULE, Pool, Oid}, TypeInfo)
+                     ets:insert(?PG_TYPES_TABLE, {{Pool, Oid}, TypeInfo})
              end, Types),
     ok.
 
@@ -106,10 +106,10 @@ lookup_typsends(TypeInfos, TypeSend) ->
     lists:filter(fun(T) -> T#type_info.typsend =:= TypeSend end, TypeInfos).
 
 lookup_type_info(Pool, Oid) ->
-    case persistent_term:get({?MODULE, Pool, Oid}, undefined) of
-        undefined ->
+    case ets:lookup(?PG_TYPES_TABLE, {Pool, Oid}) of
+        [] ->
             unknown_oid;
-        TypeInfo ->
+        [{_, TypeInfo}] ->
             TypeInfo
     end.
 

--- a/src/pg_types_app.erl
+++ b/src/pg_types_app.erl
@@ -1,0 +1,15 @@
+%%%-------------------------------------------------------------------
+%% @doc pgo_types application
+%% @end
+%%%-------------------------------------------------------------------
+-module(pg_types_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    pg_types_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/src/pg_types_server.erl
+++ b/src/pg_types_server.erl
@@ -1,0 +1,41 @@
+-module(pg_types_server).
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-include("pg_types.hrl").
+
+-record(state, {}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    %% writing new types should be rare after the initial startup
+    %% so we enable read concurrency on this table
+    _ = ets:new(?PG_TYPES_TABLE, [set, public, named_table, {read_concurrency, true}]),
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/pg_types_sup.erl
+++ b/src/pg_types_sup.erl
@@ -1,0 +1,22 @@
+-module(pg_types_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
+init([]) ->
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 5,
+                 period => 10},
+    ChildSpec = #{id => pg_types_server,
+                  start => {pg_types_server, start_link, []},
+                  shutdown => 1000},
+    {ok, {SupFlags, [ChildSpec]}}.


### PR DESCRIPTION
Types are stored in a public ets table instead of in the persistent terms. It feels safer since types could be updated and pterm can get slower with more elements in it so forcing the user to already have a bunch of terms in it just for this seems like a misuse.