### PR TITLE
support negative intervals and >24h

### DIFF
--- a/src/pg_interval.erl
+++ b/src/pg_interval.erl
@@ -9,6 +9,10 @@
 
 -include("pg_protocol.hrl").
 
+-define(USECS_PER_SEC, 1000000).
+-define(SECS_PER_MINUTE, 60).
+-define(SECS_PER_HOUR, 3600).
+
 init(_Opts) ->
     {[<<"interval_send">>], []}.
 
@@ -17,16 +21,26 @@ encode({interval, {T, D, M}}, _) ->
 encode({T, D, M}, _) ->
     <<16:?int32, (pg_time:encode_time(T)):?int64, D:?int32, M:?int32>>.
 
-decode(<<T:?int64, D:?int32, M:?int32>>, _) ->
-    {interval, {pg_time:decode_time(<<T:?int64>>), D, M}}.
+decode(<<Microseconds:?int64, Days:?int32, Months:?int32>>, _) ->
+    {interval, {decode_interval_time(Microseconds), Days, Months}}.
 
-%% encode_parameter({interval, {T, D, M}}, _, _OIDMap, true) ->
-%%     <<16:32/integer, (encode_time(T, true)):64, D:32, M:32>>;
-%% encode_parameter({T, D, M}, ?INTERVALOID, _OIDMap, true) ->
-%%     <<16:32/integer, (encode_time(T, true)):64, D:32, M:32>>;
-%% encode_parameter({T, D, M}, ?INTERVALOID, _OIDMap, false) ->
-%%     <<16:32/integer, (encode_time(T, false)):1/big-float-unit:64, D:32, M:32>>;
+%% PostgreSQL wire format: int64 microseconds (signed), int32 days (signed), int32 months (signed).
+%% Microseconds are decomposed into {Hours, Minutes, Seconds} using signed div/rem
+%% to correctly handle negative values and values exceeding 24 hours.
+decode_interval_time(0) ->
+    {0, 0, 0};
+decode_interval_time(Microseconds) ->
+    TotalSeconds = Microseconds div ?USECS_PER_SEC,
+    Remainder = Microseconds rem ?USECS_PER_SEC,
+    H = TotalSeconds div ?SECS_PER_HOUR,
+    Rem1 = TotalSeconds rem ?SECS_PER_HOUR,
+    M = Rem1 div ?SECS_PER_MINUTE,
+    S0 = Rem1 rem ?SECS_PER_MINUTE,
+    case Remainder of
+        0 -> {H, M, S0};
+        _ -> {H, M, S0 + Remainder / ?USECS_PER_SEC}
+    end.
 
 type_spec() ->
     "{interval {{Hours::integer(), Minutes::integer(), "
-    "Seconds::integer()}, Days::integer(), months::integer()}}".
+    "Seconds::integer()}, Days::integer(), Months::integer()}}".

--- a/src/pg_time.erl
+++ b/src/pg_time.erl
@@ -6,8 +6,7 @@
          encode/2,
          decode/2,
          type_spec/0,
-         encode_time/1,
-         decode_time/1]).
+         encode_time/1]).
 
 -include("pg_protocol.hrl").
 

--- a/test/interval_tests.erl
+++ b/test/interval_tests.erl
@@ -1,0 +1,89 @@
+-module(interval_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("pg_types.hrl").
+
+default_basic_test() ->
+    ?assertEqual(
+        {interval, {{3, 2, 1}, 5, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{3, 2, 1}, 5, 0}})
+    ).
+
+default_large_hours_test() ->
+    ?assertEqual(
+        {interval, {{100, 0, 0}, 0, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{100, 0, 0}, 0, 0}})
+    ).
+
+default_negative_hours_test() ->
+    ?assertEqual(
+        {interval, {{-1, 0, 0}, 0, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{-1, 0, 0}, 0, 0}})
+    ).
+
+default_negative_seconds_test() ->
+    ?assertEqual(
+        {interval, {{0, 0, -1}, 0, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{0, 0, -1}, 0, 0}})
+    ).
+
+default_negative_days_test() ->
+    ?assertEqual(
+        {interval, {{0, 0, 0}, -5, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{0, 0, 0}, -5, 0}})
+    ).
+
+default_negative_months_test() ->
+    ?assertEqual(
+        {interval, {{0, 0, 0}, 0, -3}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{0, 0, 0}, 0, -3}})
+    ).
+
+default_float_seconds_test() ->
+    ?assertEqual(
+        {interval, {{0, 0, 1.5}, 0, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{0, 0, 1.5}, 0, 0}})
+    ).
+
+default_negative_float_seconds_test() ->
+    ?assertEqual(
+        {interval, {{0, 0, -1.5}, 0, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{0, 0, -1.5}, 0, 0}})
+    ).
+
+default_zero_test() ->
+    ?assertEqual(
+        {interval, {{0, 0, 0}, 0, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{0, 0, 0}, 0, 0}})
+    ).
+
+default_complex_test() ->
+    ?assertEqual(
+        {interval, {{3, 2, 1}, 4, 77}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{3, 2, 1}, 4, 77}})
+    ).
+
+decode_100_hours_test() ->
+    Usecs = 360000000000,
+    Bin = <<Usecs:64/big-signed, 0:32/big-signed, 0:32/big-signed>>,
+    ?assertEqual({interval, {{100, 0, 0}, 0, 0}}, pg_interval:decode(Bin, #type_info{})).
+
+decode_negative_1_hour_test() ->
+    Usecs = -3600000000,
+    Bin = <<Usecs:64/big-signed, 0:32/big-signed, 0:32/big-signed>>,
+    ?assertEqual({interval, {{-1, 0, 0}, 0, 0}}, pg_interval:decode(Bin, #type_info{})).
+
+decode_negative_1_second_test() ->
+    Usecs = -1000000,
+    Bin = <<Usecs:64/big-signed, 0:32/big-signed, 0:32/big-signed>>,
+    ?assertEqual({interval, {{0, 0, -1}, 0, 0}}, pg_interval:decode(Bin, #type_info{})).
+
+decode_1000h_30m_15s_test() ->
+    Usecs = 3601815000000,
+    Bin = <<Usecs:64/big-signed, 0:32/big-signed, 0:32/big-signed>>,
+    ?assertEqual({interval, {{1000, 30, 15}, 0, 0}}, pg_interval:decode(Bin, #type_info{})).
+
+decode_negative_1_5_seconds_test() ->
+    Usecs = -1500000,
+    Bin = <<Usecs:64/big-signed, 0:32/big-signed, 0:32/big-signed>>,
+    ?assertEqual({interval, {{0, 0, -1.5}, 0, 0}}, pg_interval:decode(Bin, #type_info{})).


### PR DESCRIPTION
Fix/Feature (not sure) to support 25h (e,g, due to dst) and negative intervals which are [valid intervals in postgres](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-OUTPUT). Postgres does not normalize hours >24 into days, so even intervals with 100h are valid.

original pr: https://github.com/tsloughter/pg_types/pull/24