### PR TITLE
add postgres faithful/raw model for intervals

### DIFF
--- a/src/pg_interval.erl
+++ b/src/pg_interval.erl
@@ -7,16 +7,26 @@
          decode/2,
          type_spec/0]).
 
+-include("pg_types.hrl").
 -include("pg_protocol.hrl").
 
+init(#{interval_config := raw}) ->
+    {[<<"interval_send">>], raw};
 init(_Opts) ->
-    {[<<"interval_send">>], []}.
+    Config = application:get_env(pg_types, interval_config, []),
+    {[<<"interval_send">>], Config}.
 
-encode({interval, {T, D, M}}, _) ->
-    <<16:?int32, (pg_time:encode_time(T)):?int64, D:?int32, M:?int32>>;
+encode({interval, Microseconds, Days, Months}, _) when is_integer(Microseconds),
+                                                        is_integer(Days),
+                                                        is_integer(Months) ->
+    <<16:?int32, Microseconds:?int64, Days:?int32, Months:?int32>>;
+encode({interval, {T, D, M}}, TypeInfo) ->
+    encode({T, D, M}, TypeInfo);
 encode({T, D, M}, _) ->
     <<16:?int32, (pg_time:encode_time(T)):?int64, D:?int32, M:?int32>>.
 
+decode(<<Microseconds:?int64, Days:?int32, Months:?int32>>, #type_info{config=raw}) ->
+    {interval, Microseconds, Days, Months};
 decode(<<T:?int64, D:?int32, M:?int32>>, _) ->
     {interval, {pg_time:decode_time(<<T:?int64>>), D, M}}.
 
@@ -28,5 +38,6 @@ decode(<<T:?int64, D:?int32, M:?int32>>, _) ->
 %%     <<16:32/integer, (encode_time(T, false)):1/big-float-unit:64, D:32, M:32>>;
 
 type_spec() ->
-    "{interval {{Hours::integer(), Minutes::integer(), "
-    "Seconds::integer()}, Days::integer(), months::integer()}}".
+    "{interval, Microseconds::integer(), Days::integer(), Months::integer()} | "
+    "{interval, {{Hours::integer(), Minutes::integer(), "
+    "Seconds::integer()}, Days::integer(), Months::integer()}}".

--- a/test/interval_tests.erl
+++ b/test/interval_tests.erl
@@ -1,0 +1,60 @@
+-module(interval_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("pg_types.hrl").
+
+default_basic_test() ->
+    ?assertEqual(
+        {interval, {{3, 2, 1}, 5, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{3, 2, 1}, 5, 0}})
+    ).
+
+default_zero_test() ->
+    ?assertEqual(
+        {interval, {{0, 0, 0}, 0, 0}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{0, 0, 0}, 0, 0}})
+    ).
+
+default_complex_test() ->
+    ?assertEqual(
+        {interval, {{3, 2, 1}, 4, 77}},
+        proper_lib:encode_decode(pg_interval, [], {interval, {{3, 2, 1}, 4, 77}})
+    ).
+
+raw_basic_test() ->
+    ?assertEqual(
+        {interval, 10921000000, 5, 0},
+        proper_lib:encode_decode(pg_interval, #{interval_config => raw}, {interval, 10921000000, 5, 0})
+    ).
+
+raw_large_hours_test() ->
+    ?assertEqual(
+        {interval, 360000000000, 0, 0},
+        proper_lib:encode_decode(pg_interval, #{interval_config => raw}, {interval, 360000000000, 0, 0})
+    ).
+
+raw_negative_test() ->
+    ?assertEqual(
+        {interval, -3600000000, 0, 0},
+        proper_lib:encode_decode(pg_interval, #{interval_config => raw}, {interval, -3600000000, 0, 0})
+    ).
+
+raw_negative_days_test() ->
+    ?assertEqual(
+        {interval, 0, -5, 0},
+        proper_lib:encode_decode(pg_interval, #{interval_config => raw}, {interval, 0, -5, 0})
+    ).
+
+raw_zero_test() ->
+    ?assertEqual(
+        {interval, 0, 0, 0},
+        proper_lib:encode_decode(pg_interval, #{interval_config => raw}, {interval, 0, 0, 0})
+    ).
+
+raw_encode_from_old_format_test() ->
+    Decoded = proper_lib:encode_decode(pg_interval, #{interval_config => raw}, {interval, {{3, 2, 1}, 5, 0}}),
+    ?assertEqual({interval, 10921000000, 5, 0}, Decoded).
+
+raw_encode_bare_tuple_test() ->
+    Decoded = proper_lib:encode_decode(pg_interval, #{interval_config => raw}, {{3, 2, 1}, 5, 0}),
+    ?assertEqual({interval, 10921000000, 5, 0}, Decoded).

--- a/test/prop_interval.erl
+++ b/test/prop_interval.erl
@@ -1,0 +1,10 @@
+-module(prop_interval).
+-include_lib("proper/include/proper.hrl").
+-include("pg_types.hrl").
+
+prop_raw_format_codec() ->
+    ?FORALL(Val, raw_interval_gen(),
+            proper_lib:codec(pg_interval, #{interval_config => raw}, Val)).
+
+raw_interval_gen() ->
+    {interval, proper_lib:int64(), proper_lib:int32(), proper_lib:int32()}.


### PR DESCRIPTION
Adds a new model for intervals which is faithful to the postgres output format.
This would ideally be usable in as an alternative format such that https://github.com/lpil/pog/issues/67#issuecomment-3422132260 can access it. This new type is opt-in and should not break the existing type or dependencies